### PR TITLE
ci: run tests and pre-commit on v*.*.* base branches

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,7 +2,7 @@ name: Pre-commit checks
 
 on:
   pull_request:
-    branches: [ main, master ]
+    branches: [ main, master, 'v*.*.*' ]
 
 jobs:
   pre-commit-checks:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -31,7 +31,22 @@ jobs:
       run: |
         find . -name "*.py" -not -path "./.venv/*" -not -path "./venv/*" | xargs pylint --disable=C0114,C0115,C0116
       continue-on-error: true
-    
+
+    - name: Create throwaway test config
+      # See run-tests.yml: config.ini is git-ignored, dummy values let modules
+      # import in CI. Not real credentials; superseded by ADR 0010.
+      run: |
+        cat > config.ini <<'INI'
+        [Firebase]
+        FIREBASE_DEV_DB = https://lifttrack-test.firebaseio.com
+        FIREBASE_AUTH_UID = ci-test-uid
+
+        [Authentication]
+        SECRET_KEY = ci-test-secret-not-real
+        ALGORITHM = HS256
+        TTL = 30
+        INI
+
     - name: Run tests
       run: |
         pytest 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,24 @@ jobs:
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install pytest pytest-cov
-    
+
+    - name: Create throwaway test config
+      # config.ini and .env are git-ignored (local-only). The app reads a couple
+      # of sections at import time, so provide dummy values so modules import in
+      # CI. These are not real credentials. Superseded by ADR 0010 (pydantic
+      # settings + env layering).
+      run: |
+        cat > config.ini <<'INI'
+        [Firebase]
+        FIREBASE_DEV_DB = https://lifttrack-test.firebaseio.com
+        FIREBASE_AUTH_UID = ci-test-uid
+
+        [Authentication]
+        SECRET_KEY = ci-test-secret-not-real
+        ALGORITHM = HS256
+        TTL = 30
+        INI
+
     - name: Test with pytest
       run: |
         pytest --cov=./ --cov-report=xml

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,9 @@ name: Run Tests
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main, master, 'v*.*.*' ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main, master, 'v*.*.*' ]
 
 jobs:
   test:

--- a/interface/routers/metric_router.py
+++ b/interface/routers/metric_router.py
@@ -43,7 +43,7 @@ async def get_metrics(
         if username != current_user.username:
             logger.error(f"User {username} is not authorized to access metrics for {current_user.username}")
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You are not authorized to access this resource")
-        key = f"metrics/{username}/{exercise.replace("_", " ")}"
+        key = f"metrics/{username}/{exercise.replace('_', ' ')}"
         metrics = await db.get_data(key)
         if metrics is None:
             logger.error(f"Metrics not found for {username}/{exercise}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,19 +29,9 @@ tensorflow_hub>=0.16.0,<0.17.0
 Pillow>=9.4.0,<11.0.0
 matplotlib>=3.8.0,<3.9.0
 
-# Roboflow Inference SDK - TEMPORARILY DISABLED DUE TO NUMPY CONFLICT
-# inference-sdk>=0.50.0,<0.51.0
-inference-gpu<=0.23.0
-# CONFLICT EXPLANATION:
-# - TensorFlow 2.16.x requires: numpy<2.0.0,>=1.23.5
-# - inference-sdk 0.50.x requires: numpy>=2.0.0,<2.3.0
-# - This creates an impossible dependency resolution
-#
-# SOLUTIONS:
-# 1. Wait for TensorFlow 2.17+ which should support NumPy 2.x
-# 2. Use roboflow package instead: pip install roboflow
-# 3. Use separate environments for TensorFlow and inference-sdk
-# 4. Downgrade to older inference versions (not recommended)
+# Roboflow object detection was removed from the live path (ADR 0002), so the
+# inference-gpu SDK is no longer a dependency. It also pulled in aiortc/av, which
+# require system ffmpeg libraries and broke CI installs.
 
 # System and utilities
 psutil>=5.9.0,<5.10.0
@@ -55,7 +45,6 @@ websocket-client>=1.7.0,<1.8.0
 websockets>=13.0.0,<14.0.0
 
 # HTTP requests
-# Note: inference-sdk requires requests>=2.32.0
 requests>=2.31.0,<3.0.0
 
 # Testing and development


### PR DESCRIPTION
## Fix CI trigger gap for the rewrite bases

`run-tests.yml` and `pre-commit.yml` fired only on `main`/`master`, so **every PR targeting `v3.0.0` runs zero tests / no pre-commit checks** — including Step 1 (#72). This adds the `v*.*.*` base pattern to both workflows (covers `v3.0.0` and future semver bases).

- `run-tests.yml`: push + pull_request now include `v*.*.*`
- `pre-commit.yml`: pull_request now includes `v*.*.*`
- Left `version-check.yml` / `auto-version-bump.yml` untouched (master release-flow).

### Note: temporarily stacked on #72
Enabling CI surfaced a pre-existing break: the `v3.0.0` base's `requirements.txt` can't install (`inference-gpu` → `aiortc`/`av` needs system ffmpeg libs). That dep is dead after ADR 0002, and its removal lives in #72. So this branch is **rebased on top of #72** so CI can actually run. **Merge #72 first**; afterward this PR's diff collapses to just the two workflow files.

Per ADR 0013: tests block, coverage informational. Test deps (`pytest-asyncio`, `hypothesis`) land with the Step 2 PR that uses them.