### PR TITLE
Step 2: fix surviving-path correctness bugs (TDD)

### DIFF
--- a/core/service/pose_feature_service.py
+++ b/core/service/pose_feature_service.py
@@ -95,10 +95,13 @@ class PoseFeatureService(PoseFeatureInterface):
                 and joint2 in filtered_keypoints
                 and joint3 in filtered_keypoints
             ):
+                # Pass only the (x, y) coordinates: the third element is the
+                # keypoint confidence and must not be treated as a z-coordinate
+                # in the 2D angle computation.
                 angle = self.calculate_angle(
-                    filtered_keypoints[joint1],
-                    filtered_keypoints[joint2],
-                    filtered_keypoints[joint3],
+                    filtered_keypoints[joint1][:2],
+                    filtered_keypoints[joint2][:2],
+                    filtered_keypoints[joint3][:2],
                 )
                 angles[f"{joint1}_{joint2}_{joint3}"] = angle
 
@@ -160,8 +163,11 @@ class PoseFeatureService(PoseFeatureInterface):
             shoulder_midpoint = (ls_pos + rs_pos) / 2
             hip_midpoint = (lh_pos + rh_pos) / 2
 
-            # Calculate vertical alignment (angle with vertical axis)
-            vertical_vector = np.array([0, 1])  # Vertical reference vector
+            # Calculate vertical alignment (angle with vertical axis). In image
+            # space y grows downward, so an upright torso's shoulder->hip vector
+            # points toward -y; the reference must too, otherwise an upright torso
+            # reads ~180 deg instead of ~0.
+            vertical_vector = np.array([0, -1])  # Upward reference in image space
             body_vector = shoulder_midpoint - hip_midpoint
 
             # Normalize vectors
@@ -169,10 +175,13 @@ class PoseFeatureService(PoseFeatureInterface):
             if np.linalg.norm(body_vector) > 0:
                 body_vector = body_vector / np.linalg.norm(body_vector)
 
-                # Calculate angle between body vector and vertical
+                # Calculate angle between body vector and vertical. Commit this
+                # immediately so a degenerate lateral computation below cannot
+                # discard a valid vertical alignment.
                 cos_angle = np.dot(body_vector, vertical_vector)
                 cos_angle = np.clip(cos_angle, -1.0, 1.0)
                 vertical_alignment = np.arccos(cos_angle) * (180.0 / np.pi)
+                alignment[0] = vertical_alignment
 
                 # Calculate lateral tilt (left-right balance)
                 shoulder_vector = rs_pos - ls_pos
@@ -189,7 +198,7 @@ class PoseFeatureService(PoseFeatureInterface):
                     cos_lateral = np.clip(cos_lateral, -1.0, 1.0)
                     lateral_alignment = np.arccos(cos_lateral) * (180.0 / np.pi)
 
-                    alignment = [vertical_alignment, lateral_alignment]
+                    alignment[1] = lateral_alignment
 
         return tuple(alignment)
 
@@ -256,22 +265,23 @@ class PoseFeatureService(PoseFeatureInterface):
         angles = features.joint_angles
 
         if exercise_type == "bench_press" or exercise_type == "benchpress":
-            # Check for wrist alignment
-            left_wrist_angle = abs(
-                90 - angles.get("left_shoulder_left_elbow_left_wrist", 90)
-            )
-            right_wrist_angle = abs(
-                90 - angles.get("right_shoulder_right_elbow_right_wrist", 90)
-            )
+            # Only evaluate a check when the angle is actually present. A missing
+            # angle (occluded keypoint) must not fall back to a default that reads
+            # as bad form and produces a false positive.
+            left_elbow = angles.get("left_shoulder_left_elbow_left_wrist")
+            right_elbow = angles.get("right_shoulder_right_elbow_right_wrist")
 
-            if left_wrist_angle > 20 or right_wrist_angle > 20:
+            # Check for wrist alignment (deviation of the elbow angle from 90)
+            wrist_devs = [
+                abs(90 - a) for a in (left_elbow, right_elbow) if a is not None
+            ]
+            if any(dev > 20 for dev in wrist_devs):
                 issues["wrist_alignment"] = True
 
-            # Check for elbow position
-            left_elbow = angles.get("left_shoulder_left_elbow_left_wrist", 180)
-            right_elbow = angles.get("right_shoulder_right_elbow_right_wrist", 180)
-
-            if left_elbow > 110 or right_elbow > 110:
+            # Check for elbow position (over-extension past 110)
+            if (left_elbow is not None and left_elbow > 110) or (
+                right_elbow is not None and right_elbow > 110
+            ):
                 issues["elbow_position"] = True
 
         elif (
@@ -495,7 +505,9 @@ class PoseFeatureService(PoseFeatureInterface):
 
         # Extract body alignment
         vertical_alignment, lateral_alignment = self.extract_body_alignment(keypoints)
-        body_alignment = BodyAlignment(vertical_alignment, lateral_alignment)
+        body_alignment = BodyAlignment(
+            vertical_alignment=vertical_alignment, lateral_alignment=lateral_alignment
+        )
 
         # Create PoseFeatures object
         features = PoseFeatures(
@@ -504,7 +516,7 @@ class PoseFeatureService(PoseFeatureInterface):
             movement_patterns=movement_patterns,
             body_alignment=body_alignment,
             stability=stability,
-            speed=speed,
+            speeds=speed,
             objects=objects or {},
         )
 

--- a/interface/ws/constant.py
+++ b/interface/ws/constant.py
@@ -31,3 +31,9 @@ EXERCISE_THRESHOLDS = {
         "max_displacement": 20.0,
     },
 }
+
+# Name aliases so every exercise variant the form-analysis pipeline recognizes
+# resolves to real thresholds instead of silently falling back to "default".
+EXERCISE_THRESHOLDS["benchpress"] = EXERCISE_THRESHOLDS["bench_press"]
+EXERCISE_THRESHOLDS["romanian_deadlift"] = EXERCISE_THRESHOLDS["rdl"]
+EXERCISE_THRESHOLDS["overhead_press"] = EXERCISE_THRESHOLDS["shoulder_press"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,12 @@ requests>=2.31.0,<3.0.0
 
 # Testing and development
 pytest>=8.3.0,<8.4.0
+pytest-cov>=5.0.0,<6.0.0
+hypothesis>=6.100.0,<7.0.0
+# pytest-asyncio is intentionally deferred: the existing async router/db tests
+# are currently skipped (no asyncio plugin), and enabling the plugin before they
+# are marked/validated would surface them as failures. Add it alongside the
+# async test work in a later step.
 
 # Release management
 python-semantic-release>=8.5.0,<8.6.0

--- a/tests/core/service/test_feature_metric_service.py
+++ b/tests/core/service/test_feature_metric_service.py
@@ -1,0 +1,48 @@
+import pytest
+
+from core.entities.pose_entity import Keypoint, KeypointCollection, BodyAlignment
+from core.service.feature_metric_service import FeatureMetricService
+from core.service.pose_feature_service import PoseFeatureService
+
+
+def _ba(vertical, lateral):
+    return BodyAlignment(vertical_alignment=vertical, lateral_alignment=lateral)
+
+
+class TestBodyAlignmentScore:
+    """ADR 0013 guardrail: reintroduced/relied-on metrics must prove they produce
+    non-trivial, discriminating scores (the load_control-always-0 lesson)."""
+
+    def test_better_alignment_scores_higher(self):
+        service = FeatureMetricService()
+        good = service.compute_ba_score(_ba(1.0, 1.0), 10)
+        bad = service.compute_ba_score(_ba(40.0, 30.0), 10)
+        assert good > bad
+
+    def test_score_is_not_a_degenerate_constant(self):
+        service = FeatureMetricService()
+        scores = {
+            service.compute_ba_score(_ba(v, v), 10)
+            for v in (0.0, 5.0, 15.0, 45.0)
+        }
+        assert len(scores) > 1  # actually varies with input
+        assert scores != {0.0}
+        assert scores != {100.0}
+
+    def test_upright_torso_scores_well_end_to_end(self):
+        # Ties finding #1 to the metric: an upright torso must produce a HIGH body
+        # alignment score. Before the vertical-reference fix it read ~180 deg and
+        # scored ~0.
+        pose = PoseFeatureService()
+        vertical, lateral = pose.extract_body_alignment(
+            KeypointCollection(
+                keypoints={
+                    "left_shoulder": Keypoint(x=0.4, y=0.3, confidence=1.0),
+                    "right_shoulder": Keypoint(x=0.6, y=0.3, confidence=1.0),
+                    "left_hip": Keypoint(x=0.4, y=0.6, confidence=1.0),
+                    "right_hip": Keypoint(x=0.6, y=0.6, confidence=1.0),
+                }
+            )
+        )
+        score = FeatureMetricService().compute_ba_score(_ba(vertical, lateral), 10)
+        assert score > 90.0

--- a/tests/core/service/test_pose_feature_service.py
+++ b/tests/core/service/test_pose_feature_service.py
@@ -1,0 +1,164 @@
+import math
+
+import numpy as np
+import pytest
+from hypothesis import assume, given, strategies as st
+
+from core.entities.pose_entity import Keypoint, KeypointCollection, PoseFeatures
+from core.service.pose_feature_service import PoseFeatureService
+
+_coord = st.floats(min_value=-50.0, max_value=50.0, allow_nan=False, allow_infinity=False)
+_pt = st.tuples(_coord, _coord)
+
+
+def kc(**joints):
+    """Build a KeypointCollection from name=(x, y[, confidence]) tuples."""
+    kps = {}
+    for name, vals in joints.items():
+        x, y = vals[0], vals[1]
+        conf = vals[2] if len(vals) > 2 else 1.0
+        kps[name] = Keypoint(x=float(x), y=float(y), confidence=float(conf))
+    return KeypointCollection(keypoints=kps)
+
+
+class TestExtractBodyAlignment:
+    def test_upright_torso_has_near_zero_vertical_alignment(self):
+        # Shoulders directly above hips. In image space (y grows downward) an
+        # upright torso should read ~0 deg from vertical, not ~180.
+        service = PoseFeatureService()
+        keypoints = kc(
+            left_shoulder=(0.4, 0.3),
+            right_shoulder=(0.6, 0.3),
+            left_hip=(0.4, 0.6),
+            right_hip=(0.6, 0.6),
+        )
+        vertical, lateral = service.extract_body_alignment(keypoints)
+        assert vertical == pytest.approx(0.0, abs=1.0)
+
+    def test_vertical_alignment_preserved_when_lateral_is_degenerate(self):
+        # Coincident shoulders make the lateral (shoulder-vs-hip) computation
+        # degenerate, but the vertical alignment is still well-defined here
+        # (~18.4 deg) and must not be discarded as 0.
+        service = PoseFeatureService()
+        keypoints = kc(
+            left_shoulder=(0.6, 0.3),
+            right_shoulder=(0.6, 0.3),  # zero-length shoulder vector
+            left_hip=(0.4, 0.6),
+            right_hip=(0.6, 0.6),
+        )
+        vertical, lateral = service.extract_body_alignment(keypoints)
+        assert vertical == pytest.approx(18.43, abs=1.0)
+
+
+class TestExtractJointAngles:
+    def test_angle_ignores_confidence_as_coordinate(self):
+        # A right angle at the elbow in the image plane. The three keypoints have
+        # different confidences, which must NOT enter the angle math as a z-axis.
+        service = PoseFeatureService()
+        keypoints = kc(
+            left_shoulder=(0.5, 0.5, 0.2),
+            left_elbow=(0.5, 0.7, 0.9),
+            left_wrist=(0.7, 0.7, 0.5),
+        )
+        angles = service.extract_joint_angles(keypoints)
+        assert angles["left_shoulder_left_elbow_left_wrist"] == pytest.approx(
+            90.0, abs=0.5
+        )
+
+
+class TestDetectFormIssues:
+    def _features(self, joint_angles):
+        return PoseFeatures(
+            keypoints=KeypointCollection(keypoints={}), joint_angles=joint_angles
+        )
+
+    def test_missing_elbow_angle_does_not_flag_elbow_position(self):
+        # No elbow angle available (occluded wrist). A missing angle must not be
+        # treated as a bad-form 180-degree default and flagged.
+        service = PoseFeatureService()
+        issues = service.detect_form_issues(self._features({}), "bench_press")
+        assert not issues.get("elbow_position")
+
+    def test_present_bad_elbow_angle_still_flags_elbow_position(self):
+        # A real, measured over-extended elbow must still be flagged, so the
+        # missing-angle fix doesn't render the check dead.
+        service = PoseFeatureService()
+        features = self._features(
+            {
+                "left_shoulder_left_elbow_left_wrist": 130.0,
+                "right_shoulder_right_elbow_right_wrist": 130.0,
+            }
+        )
+        issues = service.detect_form_issues(features, "bench_press")
+        assert issues.get("elbow_position")
+
+
+class TestProcessFeatures:
+    def test_builds_body_alignment_without_error(self):
+        # The BodyAlignment pydantic model must be constructed with keyword
+        # fields; positional construction raises TypeError.
+        service = PoseFeatureService()
+        keypoints = kc(
+            left_shoulder=(0.4, 0.3),
+            right_shoulder=(0.6, 0.3),
+            left_hip=(0.4, 0.6),
+            right_hip=(0.6, 0.6),
+        )
+        features = service.process_features(keypoints)
+        assert features.body_alignment is not None
+        assert features.body_alignment.vertical_alignment == pytest.approx(
+            0.0, abs=1.0
+        )
+
+    def test_populates_speeds_field_from_movement(self):
+        # Movement between frames must land in the `speeds` field (not a dropped
+        # `speed` kwarg that pydantic silently ignores).
+        service = PoseFeatureService()
+        prev = kc(left_wrist=(0.5, 0.5), left_elbow=(0.5, 0.6))
+        curr = kc(left_wrist=(0.6, 0.5), left_elbow=(0.5, 0.6))
+        features = service.process_features(curr, previous_keypoints=prev)
+        assert features.speeds
+        assert "left_wrist" in features.speeds
+
+
+class TestCalculateAngleProperties:
+    @given(a=_pt, b=_pt, c=_pt)
+    def test_angle_is_bounded_and_symmetric(self, a, b, c):
+        service = PoseFeatureService()
+        assume(np.linalg.norm(np.subtract(a, b)) > 1.0)
+        assume(np.linalg.norm(np.subtract(c, b)) > 1.0)
+        forward = service.calculate_angle(a, b, c)
+        reverse = service.calculate_angle(c, b, a)
+        assert -1e-6 <= forward <= 180.0 + 1e-6
+        assert forward == pytest.approx(reverse, abs=1e-6)
+
+    @given(a=_pt, b=_pt, c=_pt, tx=_coord, ty=_coord)
+    def test_angle_is_translation_invariant(self, a, b, c, tx, ty):
+        service = PoseFeatureService()
+        assume(np.linalg.norm(np.subtract(a, b)) > 1.0)
+        assume(np.linalg.norm(np.subtract(c, b)) > 1.0)
+        base = service.calculate_angle(a, b, c)
+        shifted = service.calculate_angle(
+            (a[0] + tx, a[1] + ty), (b[0] + tx, b[1] + ty), (c[0] + tx, c[1] + ty)
+        )
+        assert base == pytest.approx(shifted, abs=1e-2)
+
+    @given(delta=st.floats(min_value=0.0, max_value=0.5, allow_nan=False))
+    def test_joint_angles_are_invariant_to_confidence(self, delta):
+        # Generalizes finding #2: shifting every keypoint's confidence by a
+        # constant must not change the computed geometric angle.
+        service = PoseFeatureService()
+        base = kc(
+            left_shoulder=(0.5, 0.5, 0.3),
+            left_elbow=(0.5, 0.7, 0.4),
+            left_wrist=(0.7, 0.7, 0.5),
+        )
+        shifted = kc(
+            left_shoulder=(0.5, 0.5, 0.3 + delta),
+            left_elbow=(0.5, 0.7, 0.4 + delta),
+            left_wrist=(0.7, 0.7, 0.5 + delta),
+        )
+        key = "left_shoulder_left_elbow_left_wrist"
+        assert service.extract_joint_angles(base)[key] == pytest.approx(
+            service.extract_joint_angles(shifted)[key], abs=1e-6
+        )

--- a/tests/interface/test_exercise_thresholds.py
+++ b/tests/interface/test_exercise_thresholds.py
@@ -1,0 +1,47 @@
+import importlib.util
+import pathlib
+
+# Load the standalone data module directly by path. Importing it normally would
+# run interface/ws/__init__.py, which eagerly pulls in the whole websocket router
+# (FastAPI et al.) just to read a constant dict.
+_constant_path = (
+    pathlib.Path(__file__).resolve().parents[2] / "interface" / "ws" / "constant.py"
+)
+_spec = importlib.util.spec_from_file_location("_ws_constant", _constant_path)
+_constant = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_constant)
+EXERCISE_THRESHOLDS = _constant.EXERCISE_THRESHOLDS
+
+# Exercise-name variants that the form-analysis pipeline
+# (core.service.form_analysis_service.FormAnalysisService.analyze_form)
+# recognizes and dispatches on. The threshold table must cover all of them,
+# otherwise a recognized exercise silently scores against the default
+# thresholds. (Step 3 / ADR 0005 folds this into one source-of-truth table.)
+RECOGNIZED_EXERCISES = [
+    "bench_press",
+    "benchpress",
+    "deadlift",
+    "romanian_deadlift",
+    "rdl",
+    "shoulder_press",
+    "overhead_press",
+]
+
+REQUIRED_KEYS = {
+    "max_allowed_deviation",
+    "max_allowed_variance",
+    "max_jerk",
+    "max_displacement",
+}
+
+
+def test_every_recognized_exercise_has_a_threshold_entry():
+    missing = [e for e in RECOGNIZED_EXERCISES if e not in EXERCISE_THRESHOLDS]
+    assert missing == [], (
+        f"exercises with no threshold entry (silently fall back to default): {missing}"
+    )
+
+
+def test_every_threshold_entry_is_well_formed():
+    for name, entry in EXERCISE_THRESHOLDS.items():
+        assert REQUIRED_KEYS <= set(entry), f"{name} is missing keys {REQUIRED_KEYS - set(entry)}"


### PR DESCRIPTION
## Step 2 — correctness fixes via strict red-green TDD (ADR 0009, 0013)

Each fix ships a test that provably fails against the pre-fix code. Fixes are pure-function unit tests on `core/service` plus a data test for the threshold table, per the ADR 0013 strategy.

### Fixed (7 of the 9 code-review findings)
| # | Bug | Fix |
|---|-----|-----|
| 1 | `extract_body_alignment` used a downward vertical reference `[0,1]` → upright torso read ~180° | Reference is `[0,-1]` (up in image space) |
| 2 | `extract_joint_angles` fed `(x,y,confidence)` 3-tuples into the angle math (confidence as z) | Pass only `(x,y)` |
| 3 | `detect_form_issues` defaulted missing angles to 180 → false `elbow_position` | Evaluate checks only when the angle is present |
| 4 | `EXERCISE_THRESHOLDS` lacked `romanian_deadlift`/`overhead_press`/`benchpress` → silent fallback to default | Added aliases to the canonical entries |
| 5 | `process_features` built pydantic `BodyAlignment` positionally → `TypeError` on the keypoints-in path | Keyword construction |
| 6 | `process_features` passed `speed=` (dropped) instead of the `speeds` field | Corrected field name |
| 9 | `extract_body_alignment` discarded a valid vertical alignment when the lateral calc was degenerate | Commit vertical independently |

### Tests added
- `tests/core/service/test_pose_feature_service.py` — findings above + `hypothesis` property tests for the geometry (bounded, symmetric, translation-invariant, and confidence-invariant — generalizing #2).
- `tests/core/service/test_feature_metric_service.py` — ADR 0013 metric guardrail: body-alignment score **discrimination** (good > bad) + **anti-degeneracy** (never a constant 0/100), and an end-to-end check that an upright torso now scores well (ties #1 through to the metric).
- `tests/interface/test_exercise_thresholds.py` — vocabulary-closure + well-formedness for the threshold table (loads the standalone `constant.py` by path to avoid dragging in the web stack).

### Deferred (with rationale)
- **#7** `detect_resting_state` unreachable branch — dead on the live path and object-dependent (dropped by ADR 0002); slated for Step 4 removal, not worth fixing in place.
- **#8** `compute_lc_score` shape mismatch — `load_control` is intentionally dormant per ADR 0002.
- **`pytest-asyncio`** — deferred (see requirements.txt note): enabling it now would surface the 109 currently-skipped async tests as failures before they're marked/validated.

Note: a pre-existing misspelling `max_allowed_devition` in `FeatureMetricService.compute_ba_score` was left as-is (works via positional args; out of Step 2 scope).