### PR TITLE
Step 3: per-exercise angle-range table (ADR 0005)

### DIFF
--- a/core/service/angle_range_table.py
+++ b/core/service/angle_range_table.py
@@ -1,0 +1,187 @@
+"""Per-exercise angle-range table: the single source of truth for heatmap
+bands, form score, and coaching suggestions (ADR 0005 + 0004).
+
+Each form-relevant joint angle has a correct range ``[lo, hi]`` and an orange
+``tolerance``. A measured angle inside the range is GREEN; within the tolerance
+past either edge is ORANGE; beyond that is RED. The band is surfaced at the
+``vertex`` keypoint (e.g. an elbow angle is colored at the elbow).
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
+
+
+class Band(str, Enum):
+    GREEN = "green"
+    ORANGE = "orange"
+    RED = "red"
+
+
+@dataclass(frozen=True)
+class AngleRange:
+    joint_angle: str  # key as produced by PoseFeatureService.extract_joint_angles
+    vertex: str  # keypoint where the band is colored on the heatmap
+    lo: float
+    hi: float
+    tolerance: float  # orange tolerance past either edge of [lo, hi]
+    cue: str  # coaching suggestion shown when the angle is out of range
+
+
+def classify_band(value: float, angle_range: AngleRange) -> Band:
+    """Band a measured angle against its correct range and tolerance."""
+    if angle_range.lo <= value <= angle_range.hi:
+        return Band.GREEN
+    if (
+        angle_range.lo - angle_range.tolerance
+        <= value
+        <= angle_range.hi + angle_range.tolerance
+    ):
+        return Band.ORANGE
+    return Band.RED
+
+
+def _elbow(side: str) -> AngleRange:
+    return AngleRange(
+        joint_angle=f"{side}_shoulder_{side}_elbow_{side}_wrist",
+        vertex=f"{side}_elbow",
+        lo=75.0,
+        hi=110.0,
+        tolerance=15.0,
+        cue="Keep your elbows around 90 degrees through the press.",
+    )
+
+
+def _shoulder_press_elbow(side: str) -> AngleRange:
+    return AngleRange(
+        joint_angle=f"{side}_shoulder_{side}_elbow_{side}_wrist",
+        vertex=f"{side}_elbow",
+        lo=30.0,
+        hi=100.0,
+        tolerance=15.0,
+        cue="Keep your elbows in the proper press position.",
+    )
+
+
+def _flat_back(side: str) -> AngleRange:
+    return AngleRange(
+        joint_angle=f"{side}_shoulder_{side}_hip_{side}_knee",
+        vertex=f"{side}_hip",
+        lo=150.0,
+        hi=180.0,
+        tolerance=15.0,
+        cue="Keep your back flat; hips and shoulders rise together.",
+    )
+
+
+def _hip_hinge(side: str) -> AngleRange:
+    return AngleRange(
+        joint_angle=f"{side}_shoulder_{side}_hip_{side}_knee",
+        vertex=f"{side}_hip",
+        lo=60.0,
+        hi=140.0,
+        tolerance=15.0,
+        cue="Push your hips back and keep your back flat.",
+    )
+
+
+def _neutral_head(side: str) -> AngleRange:
+    return AngleRange(
+        joint_angle=f"{side}_ear_{side}_shoulder_{side}_hip",
+        vertex=f"{side}_shoulder",
+        lo=160.0,
+        hi=180.0,
+        tolerance=15.0,
+        cue="Keep your head neutral and eyes forward.",
+    )
+
+
+# Canonical per-exercise angle ranges. The angle keys match those emitted by
+# PoseFeatureService.extract_joint_angles; the vertex is where the band is
+# colored on the heatmap.
+EXERCISE_ANGLE_RANGES: Dict[str, List[AngleRange]] = {
+    "bench_press": [_elbow("left"), _elbow("right")],
+    "deadlift": [
+        _flat_back("left"),
+        _flat_back("right"),
+        _neutral_head("left"),
+        _neutral_head("right"),
+    ],
+    "rdl": [
+        _hip_hinge("left"),
+        _hip_hinge("right"),
+        _neutral_head("left"),
+        _neutral_head("right"),
+    ],
+    "shoulder_press": [_shoulder_press_elbow("left"), _shoulder_press_elbow("right")],
+}
+
+# Name aliases so every exercise variant the pipeline recognizes resolves to the
+# canonical ranges instead of returning nothing.
+_ALIASES = {
+    "benchpress": "bench_press",
+    "romanian_deadlift": "rdl",
+    "overhead_press": "shoulder_press",
+}
+
+
+def get_angle_ranges(exercise_name: str) -> List[AngleRange]:
+    """Return the angle ranges for an exercise (empty list if unknown)."""
+    key = exercise_name.lower().replace(" ", "_")
+    key = _ALIASES.get(key, key)
+    return EXERCISE_ANGLE_RANGES.get(key, [])
+
+
+@dataclass(frozen=True)
+class AngleAssessment:
+    joint_angle: str
+    vertex: str
+    value: float
+    band: Band
+    cue: Optional[str]  # None when the band is green
+
+
+# Per-band form-score deduction. Green is on-target; orange is a slight
+# deviation; red is a severe deviation (ADR 0004).
+_BAND_DEDUCTION = {Band.GREEN: 0.0, Band.ORANGE: 0.1, Band.RED: 0.2}
+
+
+def assess_angles(
+    joint_angles: Dict[str, float], exercise_name: str
+) -> List[AngleAssessment]:
+    """Band each of the exercise's form-relevant angles that is present.
+
+    Missing angles are skipped rather than defaulted, so an occluded keypoint
+    never produces a spurious band.
+    """
+    assessments: List[AngleAssessment] = []
+    for r in get_angle_ranges(exercise_name):
+        if r.joint_angle not in joint_angles:
+            continue
+        value = joint_angles[r.joint_angle]
+        band = classify_band(value, r)
+        assessments.append(
+            AngleAssessment(
+                joint_angle=r.joint_angle,
+                vertex=r.vertex,
+                value=value,
+                band=band,
+                cue=None if band is Band.GREEN else r.cue,
+            )
+        )
+    return assessments
+
+
+def score_form(
+    joint_angles: Dict[str, float], exercise_name: str
+) -> Tuple[float, List[str]]:
+    """Derive a form accuracy (0-1) and de-duplicated suggestions from the table."""
+    assessments = assess_angles(joint_angles, exercise_name)
+    deduction = sum(_BAND_DEDUCTION[a.band] for a in assessments)
+    accuracy = max(0.0, min(1.0, 1.0 - deduction))
+
+    suggestions: List[str] = []
+    for a in assessments:
+        if a.cue and a.cue not in suggestions:
+            suggestions.append(a.cue)
+    return accuracy, suggestions

--- a/core/service/form_analysis_service.py
+++ b/core/service/form_analysis_service.py
@@ -1,241 +1,62 @@
-from typing import Dict, Any, List, Tuple
-
 from lifttrack.utils.logging_config import setup_logger
 from core.interface.form_analysis_interface import FormAnalysisInterface
 from core.entities.pose_entity import PoseFeatures, FormAnalysis
+from core.service.angle_range_table import get_angle_ranges, score_form
 
 # Setup logging
 logger = setup_logger("form-analysis-service", "comvis.log")
 
+_GOOD_FORM = "Form looks good! Keep it up!"
+_UNKNOWN = "Exercise type not recognized for form analysis."
+
 
 class FormAnalysisService(FormAnalysisInterface):
+    """Form analysis driven entirely by the per-exercise angle-range table
+    (ADR 0005), which is the single source of truth for the heatmap bands, the
+    form score, and the coaching suggestions.
+
+    Body-alignment and stability are body-level signals scored separately by the
+    feature-metric layer (compute_ba_score / compute_os_score, tuned by
+    EXERCISE_THRESHOLDS), so they are no longer duplicated here.
     """
-    Service for analyzing exercise form using pose features.
-    Responsible for determining form accuracy and providing suggestions for improvement.
-    """
+
+    def _analyze(self, features: PoseFeatures, exercise_name: str) -> FormAnalysis:
+        # A detected resting state overrides form scoring.
+        resting = {}
+        if isinstance(features.objects, dict):
+            resting = features.objects.get("resting_state", {}) or {}
+        if resting.get("is_resting", False):
+            logger.info(
+                f"User is resting - Position: {resting.get('position', 'unknown')}"
+            )
+            return FormAnalysis(accuracy=0.0, suggestions=["Idling"])
+
+        if not get_angle_ranges(exercise_name):
+            logger.warning(f"Unknown exercise type: {exercise_name}")
+            return FormAnalysis(accuracy=1.0, suggestions=[_UNKNOWN])
+
+        accuracy, suggestions = score_form(features.joint_angles, exercise_name)
+        return FormAnalysis(accuracy=accuracy, suggestions=suggestions or [_GOOD_FORM])
 
     def analyze_bench_press_form(
         self, features: PoseFeatures, exercise_name: str
     ) -> FormAnalysis:
-        """Check bench press form using enhanced feature detection."""
-        accuracy = 1.0
-        suggestions = []
-
-        # Get form issues from features
-        form_issues = features.form_issues
-
-        # Get required data for analysis
-        angles = features.joint_angles
-        stability = features.stability
-        body_alignment = features.body_alignment
-
-        # Check equipment type
-        objects = features.objects
-        equipment_type = objects.get("type", "").lower() if objects else ""
-
-        # Five-point contact check using improved stability calculation
-        if stability > 50:
-            accuracy -= 0.1
-            suggestions.append("Keep five-point contact with the bench.")
-
-        # Check wrist alignment using form_issues
-        if form_issues.get("wrist_alignment"):
-            accuracy -= 0.1
-            suggestions.append("Wrists stay aligned with elbows throughout.")
-
-        # Check back arching using enhanced body alignment
-        vertical_alignment = body_alignment.vertical_alignment if body_alignment else 0
-        if vertical_alignment > 20:  # More than 20 degrees from vertical
-            accuracy -= 0.15
-            suggestions.append("Don't over-arch; lower back stays on the bench.")
-
-        # Equipment-specific checks with improved feature detection
-        if "barbell" in equipment_type:
-            if form_issues.get("elbow_position"):
-                accuracy -= 0.15
-                suggestions.append("Maintain proper elbow angle.")
-
-            # Bar path check using enhanced movement pattern detection
-            lateral_alignment = (
-                body_alignment.lateral_alignment if body_alignment else 0
-            )
-            if lateral_alignment > 15:  # More than 15 degrees of lateral movement
-                accuracy -= 0.15
-                suggestions.append("Bar path: down and forward, then up and back.")
-
-        elif "dumbbell" in equipment_type or len(equipment_type) == 0:
-            # Enhanced dumbbell-specific checks
-            if "incline" in exercise_name:
-                # Use improved angle calculation for incline position
-                shoulder_angle = angles.get("left_shoulder_left_elbow_left_wrist", 180)
-                if abs(shoulder_angle - 45) > 10:  # More than 10 degrees off from 45
-                    accuracy -= 0.15
-                    suggestions.append("Arms at 45 degrees during incline press.")
-
-        accuracy = max(0.0, min(1.0, accuracy))
-        if not suggestions:
-            suggestions.append("Form looks good! Keep it up!")
-
-        logger.info(
-            f"Bench press form accuracy: {accuracy}, Suggestions: {suggestions}"
-        )
-        return FormAnalysis(accuracy=accuracy, suggestions=suggestions)
+        return self._analyze(features, "bench_press")
 
     def analyze_deadlift_form(
         self, features: PoseFeatures, exercise_name: str
     ) -> FormAnalysis:
-        """Check deadlift form using enhanced feature detection."""
-        accuracy = 1.0
-        suggestions = []
-
-        # Get form issues from features
-        form_issues = features.form_issues
-
-        # Enhanced feature checks
-        if form_issues.get("back_angle"):
-            accuracy -= 0.2
-            suggestions.append("Back flat, shoulder blades tight.")
-
-        if form_issues.get("head_position"):
-            accuracy -= 0.1
-            suggestions.append("Head neutral, eyes forward.")
-
-        # Use improved stability calculation
-        stability = features.stability
-        if stability > 60:
-            accuracy -= 0.15
-            suggestions.append("Lift with knees, hips, and shoulders together.")
-
-        # Use enhanced body alignment check
-        body_alignment = features.body_alignment
-        if body_alignment and body_alignment.vertical_alignment > 40:
-            accuracy -= 0.1
-            suggestions.append("Bar stays in contact with legs.")
-
-        accuracy = max(0.0, min(1.0, accuracy))
-        if not suggestions:
-            suggestions.append("Form looks good! Keep it up!")
-
-        logger.info(f"Deadlift form accuracy: {accuracy}, Suggestions: {suggestions}")
-        return FormAnalysis(accuracy=accuracy, suggestions=suggestions)
+        return self._analyze(features, "deadlift")
 
     def analyze_rdl_form(
         self, features: PoseFeatures, exercise_name: str
     ) -> FormAnalysis:
-        """Check Romanian deadlift form using enhanced feature detection."""
-        accuracy = 1.0
-        suggestions = []
-
-        # Get form issues from features
-        form_issues = features.form_issues
-
-        if form_issues.get("hip_hinge"):
-            accuracy -= 0.15
-            suggestions.append("Push hips back, keep back flat.")
-
-        # Use improved stability calculation
-        stability = features.stability
-        if stability > 100:
-            accuracy -= 0.15
-            suggestions.append("Engage core, keep back straight.")
-
-        # Enhanced body alignment checks
-        body_alignment = features.body_alignment
-        if body_alignment:
-            vertical_alignment = body_alignment.vertical_alignment
-            lateral_alignment = body_alignment.lateral_alignment
-
-            if vertical_alignment > 50 or lateral_alignment > 20:
-                accuracy -= 0.1
-                suggestions.append("Bar stays in contact with legs.")
-
-        accuracy = max(0.0, min(1.0, accuracy))
-        if not suggestions:
-            suggestions.append("Form looks good! Keep it up!")
-
-        logger.info(
-            f"Romanian deadlift form accuracy: {accuracy}, Suggestions: {suggestions}"
-        )
-        return FormAnalysis(accuracy=accuracy, suggestions=suggestions)
+        return self._analyze(features, "rdl")
 
     def analyze_shoulder_press_form(
         self, features: PoseFeatures, exercise_name: str
     ) -> FormAnalysis:
-        """Check shoulder press form using enhanced feature detection."""
-        accuracy = 1.0
-        suggestions = []
-
-        # Use enhanced stability calculation with core joints
-        stability = features.stability
-        if stability > 20:
-            accuracy -= 0.1
-            suggestions.append("Minimize body sway for stability.")
-
-        # Use improved body alignment calculation
-        body_alignment = features.body_alignment
-        if body_alignment and body_alignment.vertical_alignment > 65:
-            accuracy -= 0.1
-            suggestions.append("Stay vertically aligned, head to hips.")
-
-        # Enhanced movement pattern detection
-        angles = features.joint_angles
-        left_elbow = angles.get("left_shoulder_left_elbow_left_wrist", 180)
-        right_elbow = angles.get("right_shoulder_right_elbow_right_wrist", 180)
-
-        if (left_elbow < 30 or left_elbow > 100) or (
-            right_elbow < 30 or right_elbow > 100
-        ):
-            accuracy -= 0.15
-            suggestions.append("Keep elbows in proper position.")
-
-        accuracy = max(0.0, min(1.0, accuracy))
-        if not suggestions:
-            suggestions.append("Form looks good! Keep it up!")
-
-        logger.info(
-            f"Shoulder press form accuracy: {accuracy}, Suggestions: {suggestions}"
-        )
-        return FormAnalysis(accuracy=accuracy, suggestions=suggestions)
+        return self._analyze(features, "shoulder_press")
 
     def analyze_form(self, features: PoseFeatures, exercise_name: str) -> FormAnalysis:
-        """Main function to calculate form accuracy using enhanced feature detection."""
-        try:
-            # Check if user is resting - pass keypoints and get resting state result
-            if isinstance(features.keypoints, dict):
-                # Should not happen with proper typing, but handle for safety
-                keypoints = features.keypoints
-            else:
-                keypoints = features.keypoints.as_dict()
-
-            # First, detect if the user is in a resting state
-            resting_state = features.objects.get("resting_state", {})
-            if resting_state.get("is_resting", False):
-                logger.info(
-                    f"User is resting - Position: {resting_state.get('position', 'unknown')}"
-                )
-                return FormAnalysis(accuracy=0.0, suggestions=["Idling"])
-
-            # Normalize exercise name to handle different formats
-            exercise_name_normalized = exercise_name.lower().replace(" ", "_")
-
-            # Call appropriate exercise-specific function
-            if exercise_name_normalized in ["benchpress", "bench_press"]:
-                return self.analyze_bench_press_form(features, exercise_name_normalized)
-            elif exercise_name_normalized == "deadlift":
-                return self.analyze_deadlift_form(features, exercise_name_normalized)
-            elif exercise_name_normalized in ["romanian_deadlift", "rdl"]:
-                return self.analyze_rdl_form(features, exercise_name_normalized)
-            elif exercise_name_normalized in ["shoulder_press", "overhead_press"]:
-                return self.analyze_shoulder_press_form(
-                    features, exercise_name_normalized
-                )
-            else:
-                logger.warning(f"Unknown exercise type: {exercise_name_normalized}")
-                return FormAnalysis(
-                    accuracy=1.0,
-                    suggestions=["Exercise type not recognized for form analysis."],
-                )
-
-        except Exception as e:
-            logger.error(f"Error in analyze_form: {str(e)}")
-            raise
+        return self._analyze(features, exercise_name)

--- a/tests/core/service/test_angle_range_table.py
+++ b/tests/core/service/test_angle_range_table.py
@@ -1,0 +1,185 @@
+import pytest
+
+from core.entities.pose_entity import Keypoint, KeypointCollection
+from core.service.angle_range_table import (
+    AngleRange,
+    Band,
+    EXERCISE_ANGLE_RANGES,
+    assess_angles,
+    classify_band,
+    get_angle_ranges,
+    score_form,
+)
+from core.service.pose_feature_service import PoseFeatureService
+
+# Exercise-name variants the form-analysis pipeline recognizes (kept in sync with
+# tests/interface/test_exercise_thresholds.py and FormAnalysisService).
+RECOGNIZED_EXERCISES = [
+    "bench_press",
+    "benchpress",
+    "deadlift",
+    "romanian_deadlift",
+    "rdl",
+    "shoulder_press",
+    "overhead_press",
+]
+
+_COCO_KEYPOINTS = [
+    "nose",
+    "left_eye",
+    "right_eye",
+    "left_ear",
+    "right_ear",
+    "left_shoulder",
+    "right_shoulder",
+    "left_elbow",
+    "right_elbow",
+    "left_wrist",
+    "right_wrist",
+    "left_hip",
+    "right_hip",
+    "left_knee",
+    "right_knee",
+    "left_ankle",
+    "right_ankle",
+]
+
+
+def _emittable_angle_keys():
+    """Every joint-angle key the pipeline can produce from a full COCO-17 pose."""
+    kps = {
+        name: Keypoint(x=0.5, y=0.5 + 0.01 * i, confidence=1.0)
+        for i, name in enumerate(_COCO_KEYPOINTS)
+    }
+    angles = PoseFeatureService().extract_joint_angles(
+        KeypointCollection(keypoints=kps)
+    )
+    return set(angles.keys())
+
+
+def _range(lo=70.0, hi=110.0, tol=15.0):
+    return AngleRange(
+        joint_angle="left_shoulder_left_elbow_left_wrist",
+        vertex="left_elbow",
+        lo=lo,
+        hi=hi,
+        tolerance=tol,
+        cue="Keep your elbow around 90 degrees.",
+    )
+
+
+class TestClassifyBand:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (90.0, Band.GREEN),  # inside the range
+            (70.0, Band.GREEN),  # lower edge is inclusive
+            (110.0, Band.GREEN),  # upper edge is inclusive
+            (65.0, Band.ORANGE),  # within tolerance below the range
+            (120.0, Band.ORANGE),  # within tolerance above the range
+            (55.0, Band.ORANGE),  # exactly lo - tolerance
+            (125.0, Band.ORANGE),  # exactly hi + tolerance
+            (54.0, Band.RED),  # beyond tolerance below
+            (126.0, Band.RED),  # beyond tolerance above
+        ],
+    )
+    def test_bands(self, value, expected):
+        assert classify_band(value, _range()) == expected
+
+
+class TestTableData:
+    def test_every_recognized_exercise_has_ranges(self):
+        missing = [e for e in RECOGNIZED_EXERCISES if not get_angle_ranges(e)]
+        assert missing == [], f"exercises with no angle ranges: {missing}"
+
+    def test_aliases_resolve_to_canonical_ranges(self):
+        assert get_angle_ranges("benchpress") == get_angle_ranges("bench_press")
+        assert get_angle_ranges("romanian_deadlift") == get_angle_ranges("rdl")
+        assert get_angle_ranges("overhead_press") == get_angle_ranges("shoulder_press")
+
+    def test_ranges_are_well_formed(self):
+        for exercise, ranges in EXERCISE_ANGLE_RANGES.items():
+            assert ranges, f"{exercise} has no ranges"
+            for r in ranges:
+                assert r.lo < r.hi, f"{exercise}/{r.joint_angle}: lo >= hi"
+                assert r.tolerance > 0, f"{exercise}/{r.joint_angle}: tolerance <= 0"
+                assert r.cue.strip(), f"{exercise}/{r.joint_angle}: empty cue"
+
+    def test_vertex_is_the_middle_keypoint_of_the_angle(self):
+        # The band is colored at the joint's vertex, which must be the middle
+        # keypoint of the "a_b_c" angle key.
+        for exercise, ranges in EXERCISE_ANGLE_RANGES.items():
+            for r in ranges:
+                assert r.vertex in r.joint_angle, (
+                    f"{exercise}/{r.joint_angle}: vertex {r.vertex} not in angle key"
+                )
+
+    def test_table_angle_keys_are_emitted_by_the_pipeline(self):
+        # Vocabulary-closure (ADR 0013): every angle the table scores must be one
+        # the pipeline can actually produce, or it silently never bands.
+        emittable = _emittable_angle_keys()
+        unknown = sorted(
+            {
+                r.joint_angle
+                for ranges in EXERCISE_ANGLE_RANGES.values()
+                for r in ranges
+                if r.joint_angle not in emittable
+            }
+        )
+        assert unknown == [], f"table references angles the pipeline never emits: {unknown}"
+
+
+class TestAssessAngles:
+    def test_bands_present_angles_at_their_vertex(self):
+        joint_angles = {
+            "left_shoulder_left_elbow_left_wrist": 90.0,  # green
+            "right_shoulder_right_elbow_right_wrist": 130.0,  # red (past 110+15)
+        }
+        by_vertex = {a.vertex: a for a in assess_angles(joint_angles, "bench_press")}
+        assert by_vertex["left_elbow"].band == Band.GREEN
+        assert by_vertex["left_elbow"].cue is None
+        assert by_vertex["right_elbow"].band == Band.RED
+        assert by_vertex["right_elbow"].cue
+
+    def test_missing_angles_are_skipped(self):
+        assessments = assess_angles(
+            {"right_shoulder_right_elbow_right_wrist": 90.0}, "bench_press"
+        )
+        assert [a.vertex for a in assessments] == ["right_elbow"]
+
+
+class TestScoreForm:
+    _PERFECT = {
+        "left_shoulder_left_elbow_left_wrist": 90.0,
+        "right_shoulder_right_elbow_right_wrist": 90.0,
+    }
+    _BAD = {
+        "left_shoulder_left_elbow_left_wrist": 130.0,
+        "right_shoulder_right_elbow_right_wrist": 130.0,
+    }
+
+    def test_perfect_form_full_score_no_suggestions(self):
+        accuracy, suggestions = score_form(self._PERFECT, "bench_press")
+        assert accuracy == pytest.approx(1.0)
+        assert suggestions == []
+
+    def test_worse_form_scores_lower_with_cue(self):
+        good, _ = score_form(self._PERFECT, "bench_press")
+        bad, cues = score_form(self._BAD, "bench_press")
+        assert bad < good
+        assert cues
+
+    def test_score_is_not_a_degenerate_constant(self):
+        scores = {
+            score_form(
+                {
+                    "left_shoulder_left_elbow_left_wrist": v,
+                    "right_shoulder_right_elbow_right_wrist": v,
+                },
+                "bench_press",
+            )[0]
+            for v in (90.0, 118.0, 130.0)  # green, orange, red
+        }
+        assert len(scores) > 1
+        assert scores != {0.0}
+        assert scores != {1.0}

--- a/tests/core/service/test_form_analysis_service.py
+++ b/tests/core/service/test_form_analysis_service.py
@@ -1,0 +1,56 @@
+import pytest
+
+from core.entities.pose_entity import KeypointCollection, PoseFeatures
+from core.service.form_analysis_service import FormAnalysisService
+
+
+def _features(joint_angles, objects=None):
+    return PoseFeatures(
+        keypoints=KeypointCollection(keypoints={}),
+        joint_angles=joint_angles,
+        objects=objects or {},
+    )
+
+
+_BAD_BENCH = {
+    "left_shoulder_left_elbow_left_wrist": 130.0,
+    "right_shoulder_right_elbow_right_wrist": 130.0,
+}
+_GOOD_BENCH = {
+    "left_shoulder_left_elbow_left_wrist": 90.0,
+    "right_shoulder_right_elbow_right_wrist": 90.0,
+}
+
+
+class TestTableDrivenAnalyzeForm:
+    def test_bad_joint_angle_lowers_accuracy_and_suggests_cue(self):
+        svc = FormAnalysisService()
+        result = svc.analyze_form(_features(_BAD_BENCH), "bench_press")
+        assert result.accuracy < 1.0
+        assert any("elbow" in s.lower() for s in result.suggestions)
+
+    def test_good_form_is_full_accuracy(self):
+        svc = FormAnalysisService()
+        result = svc.analyze_form(_features(_GOOD_BENCH), "bench_press")
+        assert result.accuracy == pytest.approx(1.0)
+
+    def test_resting_state_is_idling(self):
+        svc = FormAnalysisService()
+        result = svc.analyze_form(
+            _features({}, objects={"resting_state": {"is_resting": True}}),
+            "bench_press",
+        )
+        assert result.accuracy == 0.0
+        assert result.suggestions == ["Idling"]
+
+    def test_unknown_exercise_is_not_scored(self):
+        svc = FormAnalysisService()
+        result = svc.analyze_form(_features({"x": 1.0}), "zumba")
+        assert "not recognized" in result.suggestions[0].lower()
+
+    def test_per_exercise_method_matches_analyze_form(self):
+        svc = FormAnalysisService()
+        f = _features(_BAD_BENCH)
+        assert svc.analyze_bench_press_form(f, "bench_press") == svc.analyze_form(
+            f, "bench_press"
+        )


### PR DESCRIPTION
## Step 3 — the angle-range table as single source of truth (ADR 0005, 0004)

Introduces `core/service/angle_range_table.py`: for each exercise, each form-relevant joint angle has a correct range `[lo, hi]` + an orange `tolerance`, colored at its `vertex` keypoint. This one table now drives the **form score, the suggestions, and (next) the heatmap bands** — replacing the scattered per-exercise constants.

### Added (TDD, red-green per piece)
- **`Band` + `classify_band`** — inside range → green, within tolerance past an edge → orange, beyond → red (boundaries tested).
- **`EXERCISE_ANGLE_RANGES`** + `get_angle_ranges` with aliases (`benchpress`/`romanian_deadlift`/`overhead_press`). Angle keys match what `extract_joint_angles` emits.
- **`assess_angles`** — per-joint `AngleAssessment(vertex, value, band, cue)` — the data the heatmap (Step 5) will consume. Missing angles are skipped, not defaulted.
- **`score_form`** — accuracy (green 0 / orange −0.1 / red −0.2 per joint) + de-duplicated cues.

### Rewired
`FormAnalysisService` — all five interface methods now funnel through the table. This also fixes a latent crash in the old `analyze_form` (`KeypointCollection has no attribute 'as_dict'`) and makes the score respond to actual joint angles (the old code only read `form_issues` and ignored `joint_angles`). The live path (`feature_repository.get_suggestions`) picks this up automatically.

### Tests (24 new; suite 34 → 58, 0 failures)
- `test_angle_range_table.py`: band logic (parametrized boundaries), data-integrity, alias resolution, vertex-is-middle-keypoint, **vocabulary-closure** (every table angle is one the pipeline emits), and `score_form` discrimination + anti-degeneracy (ADR 0013 guardrail).
- `test_form_analysis_service.py`: table-driven accuracy/suggestions, resting-state, unknown-exercise, per-exercise method parity.

### Scope notes
- Body-alignment and stability are intentionally **not** in the angle table — they are body-level metrics scored separately (`compute_ba_score`/`compute_os_score` with `EXERCISE_THRESHOLDS`). This de-duplicates the body-alignment checks the old `analyze_*_form` methods each re-implemented.
- `detect_form_issues` is left in place (interface-mandated, fixed in Step 2) but its output is no longer consumed by the scoring path; removal is Step-4 cleanup when the pose interface is revised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)