### PR TITLE
Add config.ini/.env templates and setup guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,42 @@
+# LiftTrack API — .env template
+#
+# Copy this file to `.env` in the repo root and fill in real values:
+#     cp .env.example .env
+#
+# `.env` is git-ignored. These are loaded by pydantic BaseSettings (utils/*),
+# grouped by env-var prefix. `config.ini` (see config.ini.example) is what the
+# API needs to *boot*; the FIREBASE_* values here are what Firebase needs to
+# actually *work* at runtime (login, session persistence).
+
+# --- Firebase runtime (utils.FirebaseSettings, prefix FIREBASE_) ---
+# Same RTDB URL as config.ini's FIREBASE_DEV_DB.
+FIREBASE_DATABASE_URL=https://your-project-default-rtdb.firebaseio.com
+# Path to the Firebase Admin SDK service-account JSON (download from
+# Firebase Console → Project settings → Service accounts → Generate new
+# private key). Keep the file out of git.
+FIREBASE_ADMIN_SDK=./serviceAccountKey.json
+# Same UID as config.ini's FIREBASE_AUTH_UID.
+FIREBASE_AUTH_UID=your-service-account-uid
+# RTDB access token / database secret used by the REST client.
+FIREBASE_AUTH_TOKEN=your-firebase-db-secret
+
+# --- Application (utils.AppSettings, prefix APP_; all optional, shown with defaults) ---
+APP_NAME=LiftTrack
+APP_DEBUG_MODE=false
+APP_HOST=0.0.0.0
+APP_PORT=8000
+APP_FILE_LOG_LEVEL=INFO
+APP_SCREEN_LOG_LEVEL=INFO
+
+# --- CORS (utils.CorsSettings, prefix CORS_; optional; values are JSON arrays) ---
+# CORS_ALLOWED_ORIGINS=["*"]
+# CORS_ALLOW_CREDENTIALS=true
+
+# --- Optional integrations (not required to boot; leave unset if unused) ---
+# Roboflow inference SDK (utils.InferenceSdkSettings, prefix ROBOFLOW_).
+# ROBOFLOW_API_URL=
+# ROBOFLOW_API_KEY=
+# ROBOFLOW_PROJECT_ID=
+# ROBOFLOW_MODEL_VERSION=1
+# MongoDB (utils.MongoDbSettings, prefix MONGO_).
+# MONGO_URI=

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,0 +1,26 @@
+# LiftTrack API — config.ini template
+#
+# Copy this file to `config.ini` in the repo root and fill in real values:
+#     cp config.ini.example config.ini
+#
+# `config.ini` is git-ignored (`*.ini`). The API reads it at import time
+# (lifttrack/__init__.py); every key below is read WITHOUT a fallback, so the
+# server raises on startup if any is missing. These are the minimum required to
+# boot the API for manual testing.
+
+[Authentication]
+# JWT signing secret. Generate a long random value, e.g.:
+#     python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY = replace-with-a-long-random-secret
+# JWT algorithm (HS256 is the default the app/API expect).
+ALGORITHM = HS256
+# Access-token lifetime, in minutes.
+TTL = 30
+
+[Firebase]
+# Realtime Database URL, e.g.
+#   https://<project-id>-default-rtdb.<region>.firebasedatabase.app
+FIREBASE_DEV_DB = https://your-project-default-rtdb.firebaseio.com
+# UID applied as the RTDB admin auth-variable override for server access
+# (matches a service-account/admin UID in your Firebase project).
+FIREBASE_AUTH_UID = your-service-account-uid

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,0 +1,57 @@
+# Configuration & local run (manual testing)
+
+The API needs two git-ignored config files to run. Templates are checked in;
+copy and fill them with real values.
+
+## 1. `config.ini` (required to boot)
+
+Read at import time (`lifttrack/__init__.py`) with no fallbacks — the server
+**won't start** without it.
+
+```sh
+cp config.ini.example config.ini
+```
+
+Fill:
+- `[Authentication]` — `SECRET_KEY` (generate: `python -c "import secrets; print(secrets.token_hex(32))"`), `ALGORITHM` (`HS256`), `TTL` (minutes).
+- `[Firebase]` — `FIREBASE_DEV_DB` (RTDB URL), `FIREBASE_AUTH_UID`.
+
+## 2. `.env` (Firebase runtime: login, session persistence)
+
+Loaded by pydantic settings (`utils/*`).
+
+```sh
+cp .env.example .env
+```
+
+Fill the `FIREBASE_*` values (same DB URL/UID as `config.ini`, plus a
+`FIREBASE_ADMIN_SDK` path to your service-account JSON and `FIREBASE_AUTH_TOKEN`).
+`APP_*`/`CORS_*` are optional; `ROBOFLOW_*`/`MONGO_*` aren't needed to boot.
+
+Download the service-account JSON from Firebase Console → Project settings →
+Service accounts → *Generate new private key*, and point `FIREBASE_ADMIN_SDK`
+at it. Keep it out of git.
+
+## 3. Run the API
+
+```sh
+.venv/Scripts/python.exe -m uvicorn main:app --host 0.0.0.0 --port 8000
+```
+
+`--host 0.0.0.0` so a phone on the same LAN can reach it. Sanity check:
+`GET http://<PC-LAN-IP>:8000/ping` → `{"status":"ok"}`.
+
+## 4. Point the app at this API (manual keypoints-in test)
+
+The app reads the websocket base URL from a build-time define (`LiveConfig`,
+default `wss://proxmox.lift-track.com`). For a **local** dev API, build the
+debug APK against your PC's LAN IP over plain `ws://`:
+
+```sh
+# in the app repo (Z:/liftttrack)
+flutter build apk --debug --dart-define=LIVE_WS_BASE_URL=ws://<PC-LAN-IP>:8000
+```
+
+The client then connects to `ws://<PC-LAN-IP>:8000/v2/exercise-tracking?...`,
+streams `keypoints`, and consumes `bands`/`coaching`. Use the in-app floating
+**DEBUG** overlay to trace any runtime errors on the device.


### PR DESCRIPTION
Adds checked-in templates for the two git-ignored config files the API needs to
run, so the environment can be reproduced for manual (use) testing. The API
otherwise won't boot — `config.ini` is read at import with no fallbacks.

## What
- `config.ini.example` — `[Authentication]` (SECRET_KEY/ALGORITHM/TTL) and
  `[Firebase]` (FIREBASE_DEV_DB/FIREBASE_AUTH_UID). These are read at import
  (`lifttrack/__init__.py`, `lifttrack/auth.py`, `infrastructure/di/db.py`) with
  no defaults — **required to boot**.
- `.env.example` — pydantic settings by prefix: `FIREBASE_*` (runtime: login,
  session persistence, admin SDK path), optional `APP_*`/`CORS_*`, and
  commented `ROBOFLOW_*`/`MONGO_*` (not instantiated at boot).
- `docs/CONFIG.md` — copy/fill steps, generating `SECRET_KEY`, the Firebase
  service-account JSON, `uvicorn main:app` run command, and pointing the app at
  a local API via `--dart-define=LIVE_WS_BASE_URL=ws://<PC-LAN-IP>:8000`
  (endpoint `/v2/exercise-tracking`).

Templates only — no real files (`*.ini` and `.env` stay git-ignored).

## Verification
- Filled `config.ini` from the template with dummy values → `import main`
  succeeds (full FastAPI app boots; `.env` optional for import, defaults apply).