### PR TITLE
Pin bcrypt <4.1 for passlib 1.7.4 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,10 @@ jsonschema>=4.20.0,<5.0.0
 passlib>=1.7.4,<1.8.0
 python_jose>=3.3.0,<3.4.0
 cryptography>=42.0.8,<44.0.0
-bcrypt>=4.0.1
+# Pinned <4.1: passlib 1.7.4's bcrypt backend is incompatible with bcrypt 4.1+
+# (it probes with a >72-byte string that newer bcrypt rejects instead of
+# truncating, breaking all hashing). See ADR/notes; unpin only if passlib moves.
+bcrypt>=4.0.1,<4.1
 
 # Database and Firebase
 firebase_admin>=6.6.0,<6.7.0


### PR DESCRIPTION
Signup/login hashing raised `ValueError: password cannot be longer than 72
bytes` for **any** password (even 1 char), surfacing to the app as a 400 on
signup.

## Root cause
`bcrypt>=4.0.1` resolved to **5.0.0**. passlib 1.7.4's bcrypt backend probes the
library with a >72-byte test string; bcrypt ≥ 4.1 now **rejects** that instead
of silently truncating, so `CryptContext(schemes=["bcrypt"]).hash(...)` throws
on every call (both `lifttrack/auth.py` and `infrastructure/auth/authenticator.py`).

## Fix
Pin `bcrypt>=4.0.1,<4.1` (resolves to 4.0.1, the last release passlib 1.7.4
supports).

## Verification (local venv, bcrypt downgraded to 4.0.1)
- `get_password_hash('1')` → valid `$2b$12$…` hash (previously raised).
- Round-trip: `hash_context.verify('1', h)` → True; wrong password → False.
  So both signup hashing and login verification work.