### PR TITLE
fix: score shoulder press on arm elevation so form discriminates

### DIFF
--- a/core/service/angle_range_table.py
+++ b/core/service/angle_range_table.py
@@ -52,14 +52,19 @@ def _elbow(side: str) -> AngleRange:
     )
 
 
-def _shoulder_press_elbow(side: str) -> AngleRange:
+def _overhead_press(side: str) -> AngleRange:
+    # Score the arm *elevation* (wrist-shoulder-hip), not the elbow flexion: a
+    # real press drives the arm overhead (~150-180 deg at lockout), while an
+    # arbitrary partial arm-raise stays near 90 deg. The old elbow band
+    # (30-100 deg) greened almost any bent arm, so form never discriminated
+    # (ADR 0013 anti-degeneracy).
     return AngleRange(
-        joint_angle=f"{side}_shoulder_{side}_elbow_{side}_wrist",
-        vertex=f"{side}_elbow",
-        lo=30.0,
-        hi=100.0,
-        tolerance=15.0,
-        cue="Keep your elbows in the proper press position.",
+        joint_angle=f"{side}_wrist_{side}_shoulder_{side}_hip",
+        vertex=f"{side}_shoulder",
+        lo=150.0,
+        hi=180.0,
+        tolerance=30.0,
+        cue="Press the weight fully overhead — arms straight above your shoulders.",
     )
 
 
@@ -113,7 +118,7 @@ EXERCISE_ANGLE_RANGES: Dict[str, List[AngleRange]] = {
         _neutral_head("left"),
         _neutral_head("right"),
     ],
-    "shoulder_press": [_shoulder_press_elbow("left"), _shoulder_press_elbow("right")],
+    "shoulder_press": [_overhead_press("left"), _overhead_press("right")],
 }
 
 # Name aliases so every exercise variant the pipeline recognizes resolves to the

--- a/tests/core/service/test_angle_range_table.py
+++ b/tests/core/service/test_angle_range_table.py
@@ -183,3 +183,49 @@ class TestScoreForm:
         assert len(scores) > 1
         assert scores != {0.0}
         assert scores != {1.0}
+
+
+class TestShoulderPressDiscrimination:
+    """P3 / ADR 0013: a real overhead press must out-score an arm-raise instead
+    of everything reading ~100%. Driven through the real keypoint -> angle
+    pipeline so the table and PoseFeatureService agree on the angle key."""
+
+    @staticmethod
+    def _score(shoulders, hips, wrists):
+        # Synthetic COCO pose (normalized [0,1], y-down per ADR 0003) with just
+        # the keypoints the wrist-shoulder-hip angle needs.
+        (lsx, lsy), (rsx, rsy) = shoulders
+        (lhx, lhy), (rhx, rhy) = hips
+        (lwx, lwy), (rwx, rwy) = wrists
+        kps = {
+            "left_shoulder": Keypoint(x=lsx, y=lsy, confidence=1.0),
+            "right_shoulder": Keypoint(x=rsx, y=rsy, confidence=1.0),
+            "left_hip": Keypoint(x=lhx, y=lhy, confidence=1.0),
+            "right_hip": Keypoint(x=rhx, y=rhy, confidence=1.0),
+            "left_wrist": Keypoint(x=lwx, y=lwy, confidence=1.0),
+            "right_wrist": Keypoint(x=rwx, y=rwy, confidence=1.0),
+        }
+        angles = PoseFeatureService().extract_joint_angles(
+            KeypointCollection(keypoints=kps)
+        )
+        return score_form(angles, "shoulder_press")
+
+    _SHOULDERS = [(0.40, 0.40), (0.60, 0.40)]
+    _HIPS = [(0.42, 0.75), (0.58, 0.75)]
+    # Lockout: wrists straight above the shoulders.
+    _OVERHEAD = [(0.40, 0.10), (0.60, 0.10)]
+    # Lateral/front raise at shoulder height — arms out, not pressed up.
+    _ARM_RAISE = [(0.15, 0.40), (0.85, 0.40)]
+
+    def test_overhead_press_scores_full(self):
+        accuracy, suggestions = self._score(
+            self._SHOULDERS, self._HIPS, self._OVERHEAD
+        )
+        assert accuracy == pytest.approx(1.0)
+        assert suggestions == []
+
+    def test_arm_raise_scores_lower_with_a_cue(self):
+        good, _ = self._score(self._SHOULDERS, self._HIPS, self._OVERHEAD)
+        bad, cues = self._score(self._SHOULDERS, self._HIPS, self._ARM_RAISE)
+        assert bad < good
+        assert cues


### PR DESCRIPTION
Addresses **P3** from the 2026-07-08 sample-run analysis: accuracy sat at ~100%
for arbitrary arm-raises that aren't a real shoulder press, so form never
discriminated (ADR 0013 anti-degeneracy).

### Root cause
`shoulder_press` banded only the **elbow flexion**
(`shoulder_elbow_wrist`) with a huge green range (30–100°), so almost any bent
arm scored green. It also never rewarded lockout (a straight arm at the top,
~180°, fell *outside* the range).

### Fix
Score the **arm elevation** instead — `wrist_shoulder_hip`, the angle at the
shoulder between the wrist and the hip (vertex = shoulder):

| Position | Angle | Band |
|---|---|---|
| Pressed overhead (lockout) | ~150–180° | green |
| Bottom of press | ~120–150° | orange |
| Partial / lateral arm-raise | ~90° | red |

`lo=150, hi=180, tolerance=30`. This angle key is already emitted by
`PoseFeatureService.extract_joint_angles`, so it passes the vocabulary-closure
test.

### Tests
New `TestShoulderPressDiscrimination` drives a synthetic overhead press vs. an
arm-raise **through the real keypoint → angle pipeline** and asserts the press
out-scores the raise with a cue (red-green: fails against the pre-fix table,
which produced no shoulder-press angle at all for these poses). Full suite:
74 passed, 94 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
